### PR TITLE
Settings: Display actual device peak refresh rate in summary

### DIFF
--- a/res/values/awaken_strings.xml
+++ b/res/values/awaken_strings.xml
@@ -311,4 +311,7 @@
     <!-- Ignore window secure -->
     <string name="ignore_window_secure_title">Ignore secure window flag</string>
     <string name="ignore_window_secure_summary">Remove screenshot and screenrecord limits for all apps. This can be convenient in some cases but may lead to privacy leaks.</string>
+
+    <!-- Display settings screen, peak refresh rate settings summary [CHAR LIMIT=NONE] -->
+    <string name="peak_refresh_rate_summary_custom">Automatically raises the refresh rate from 60 to %1$d Hz for some content. Increases battery usage.</string>
 </resources>

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -160,7 +160,6 @@
         <SwitchPreference
             android:key="peak_refresh_rate"
             android:title="@string/peak_refresh_rate_title"
-            android:summary="@string/peak_refresh_rate_summary"
             settings:controller="com.android.settings.display.PeakRefreshRatePreferenceController"/>
 
         <SwitchPreference

--- a/src/com/android/settings/display/PeakRefreshRatePreferenceController.java
+++ b/src/com/android/settings/display/PeakRefreshRatePreferenceController.java
@@ -89,6 +89,10 @@ public class PeakRefreshRatePreferenceController extends TogglePreferenceControl
         super.displayPreference(screen);
 
         mPreference = screen.findPreference(getPreferenceKey());
+
+        final String summary = mContext.getString(R.string.peak_refresh_rate_summary_custom,
+                (int)mPeakRefreshRate);
+        mPreference.setSummary(summary);
     }
 
     @Override


### PR DESCRIPTION
The hardcoded value of 90Hz might be incorrect for some devices.

Squashed with:
Author: Michael W <baddaemon87@gmail.com>
Date:   Thu Oct 14 19:22:29 2021 +0200

    Fixup "settings: display actual device peak refresh rate in summary"

    This partially reverts commit 892841cc0bdbfab787a35952cb38e67ebcc07e9a.

    * peak_refresh_rate_summary ->
      peak_refresh_rate_summary_custom

    Change-Id: I11140715990215329a0813a232651bfbd230828d

Change-Id: I6074f081855f20f8c4b973e893175d9b0f79b3ab